### PR TITLE
Fixed Runtime.js to not always remove last argument

### DIFF
--- a/dist/sandbox/runtime.js
+++ b/dist/sandbox/runtime.js
@@ -32,8 +32,16 @@ environment.define = (name) => {
 };
 environment.defineAsync = (name) => {
     environment[name] = (...args) => {
-        const callback = args.pop();
-        return environment.dispatch(name, args, callback);
+        if (typeof args[args.length-1] == 'function') { // water-fall function
+            let callback = args.pop();
+            return environment.dispatch(name, args, callback);
+        }else {
+            return new Promise(async(resolve, reject) => { // standard await function
+                environment.dispatch(name, args, function(value) {
+                    resolve(value);
+                })
+            })
+        }
     };
 };
 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';

--- a/vanesca-tests/fix1.js
+++ b/vanesca-tests/fix1.js
@@ -1,0 +1,28 @@
+
+process.stdout.write("\u001b[2J\u001b[00H") // clear screen
+const { Sandbox, SandboxCluster } = require('../v8-sandbox')
+let sandbox = new Sandbox({ memory: 1000, require: __dirname + '/functions1.js' })
+
+let code = `
+    async function test() {
+
+        // always works! (water-fall/callback embedded)
+        addNumbers(1, 2, function(result) {
+            if(result.error) console.log('error1:', result.error)
+            if(result.value) console.log('value1:', result.value)
+        })
+
+        // only works with the runtime.js fix (standard await)
+        // otherwise the last argument is removed, because it expects a callback (embedded)
+        let {error, value} = await addNumbers(1, 2)
+        if(error) console.log('error2:', error)
+        if(value) console.log('value2:', value)
+    }
+    test()
+`; // always end with semicolon
+
+(async () => {
+
+    // test 1 (runs in async)
+    await sandbox.execute({ code })
+})()

--- a/vanesca-tests/functions1.js
+++ b/vanesca-tests/functions1.js
@@ -1,0 +1,10 @@
+
+// Create or require your own functions and libraries (more safe)
+
+// Async (water-fall method / callback)
+defineAsync('addNumbers', ([ value1, value2 ], { respond, callback }) => {
+    respond() // always required!
+    setTimeout(() => {
+        callback({error: null, value: value1 + value2}) // send to sandbox
+    }, 1000) // 1 sec delay (for testing)
+})


### PR DESCRIPTION
Fixed a bug where if you used any Async method in a standard await function, it would always remove the last argument of the function you are trying to call (if you supplied any)
Which isn't supposed to happen.

This doesn't happen if you use the default Async method, via the water-fall method, where the function you are trying to call is embedded to the call itself.

Now supports both methods!
1. Water-fall (call-back embedded)
2. Standard await.